### PR TITLE
Fixed TLS version table

### DIFF
--- a/blackbox-exporter/blackbox-exporter.json
+++ b/blackbox-exporter/blackbox-exporter.json
@@ -1155,7 +1155,7 @@
               "Value": true,
               "Value #A": true,
               "__name__": true,
-              "instance": true,
+              "instance": false,
               "job": true,
               "version": false
             },


### PR DESCRIPTION
Now it corresponds with the picture. The TLS version table is missing the "instance" field.